### PR TITLE
Update OSS information, readme and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2018 Rubrik Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. 

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,8 @@ testbuild:
 
 .PHONY: clean
 clean:
-	rm -f ./internal/codegen/codegen ./internal/tests/tests.go ./assert/assert.go ./expect/expect.go
+	rm -f \
+		./internal/codegen/codegen \
+		./internal/tests/tests.go \
+		./assert/assert.go \
+		./expect/expect.go

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-[API Documentation here.](https://godoc.org/github.com/rubrikinc/testwell/assert)
+# testwell
 
-# testwel
-A small set of convenient testing functions for Go.
+[![License](https://img.shields.io/badge/license-BSD-blue.svg)](https://github.com/rubrikinc/testwell/blob/master/LICENSE)
+[![GoDoc](https://godoc.org/github.com/rubrikinc/testwell/assert?status.svg)](https://godoc.org/github.com/rubrikinc/testwell/assert)
+[![Go Report Card](https://goreportcard.com/badge/rubrikinc/testwell)](http://goreportcard.com/report/rubrikinc/testwell)
+
+A small set of type-safe convenient testing functions for Go.
 
 Two identical packages (same API) are provided: `expect` and `assert`.
 
@@ -36,7 +39,10 @@ Use `godoc`. For example:
 godoc -http :9090
 ```
 
-Then navigate to [http://localhost:9090/pkg/github.com/rubrikinc/testwell/assert/].
+Then navigate to
+[localhost](http://localhost:9090/pkg/github.com/rubrikinc/testwell/assert/).
+Alternatively, can view them online
+[here](https://godoc.org/github.com/rubrikinc/testwell/assert).
 
 ## Main design rules
 
@@ -68,6 +74,18 @@ The generated code expect to find available in the same package the function
 responsible for logging out the failed test, and taking the approach following
 action (fail now, mark test as failed or log it for unit testing).
 
+## Get involved
+
+We are happy to receive bug reports, fixes, documentation enhancements, and
+other improvements.
+
+Please report bugs via the
+[github issue tracker](https://github.com/rubrikinc/testwell/issues).
+
+## Licensing
+
+This library is MIT-licensed.
+
 ## Motivation
 
 This is our own version of set of helpers function for testing in Go. This
@@ -76,7 +94,7 @@ that.
 
 ### Testify is not the best choice
 
-Testify [https://github.com/stretchr/testify] has become more or less the
+[Testify](https://github.com/stretchr/testify) has become more or less the
 standard for convenient test functions. However it has many flaws.
 
 In Go, no two different types can be compared (with the notable exception of


### PR DESCRIPTION
Notify that the project is using the MIT OSS license. Update the README
file to more accurately reflect the project.