### PR TITLE
Fix `make test` for Go 1.10+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ generate: ./internal/tests/tests.go ./assert/assert.go ./expect/expect.go
 
 .PHONY: test
 test:
-	go test ./internal/tests/
+	go test -vet off ./internal/tests/
 
 ./assert/assert.go: ./internal/assert.tmpl
 	rm -f $@


### PR DESCRIPTION
As mentioned in [Go 1.10 Release Notes](https://go.dev/doc/go1.10),
Version 1.10 onward, `go test` automatically runs `vet` for test code too.
That fails the test code compilation with the same issue as mentioned
in https://github.com/golang/go/issues/24342.

To make the tests compile again, in this change, we disable `vet`
for tests.