### PR TITLE
Remove error from nil-check

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -2798,8 +2798,6 @@ func NotContainsUintptr(t testing.T,
 }
 
 // Nil tests if the passed value is Nil. See also Empty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	if h, ok := t.(testing.Helper); ok {
@@ -2818,8 +2816,6 @@ func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
 }
 
 // NotNil tests if the passed value is not Nil. See also NotEmpty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	if h, ok := t.(testing.Helper); ok {

--- a/expect/expect.go
+++ b/expect/expect.go
@@ -2798,8 +2798,6 @@ func NotContainsUintptr(t testing.T,
 }
 
 // Nil tests if the passed value is Nil. See also Empty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	if h, ok := t.(testing.Helper); ok {
@@ -2818,8 +2816,6 @@ func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
 }
 
 // NotNil tests if the passed value is not Nil. See also NotEmpty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	if h, ok := t.(testing.Helper); ok {

--- a/internal/assert.tmpl
+++ b/internal/assert.tmpl
@@ -236,8 +236,6 @@ func NotEqualTypes(t testing.T,
 {{ end }}
 
 // Nil tests if the passed value is Nil. See also Empty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 {{ $msgfmtcomment }}
 func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
     {{- template "helper" "t" }}
@@ -253,8 +251,6 @@ func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
 }
 
 // NotNil tests if the passed value is not Nil. See also NotEmpty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 {{ $msgfmtcomment }}
 func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
     {{- template "helper" "t" }}

--- a/internal/cmp/nil.go
+++ b/internal/cmp/nil.go
@@ -22,7 +22,7 @@ func Nil(nullable interface{}) (ok bool, err error) {
 	case reflect.Slice:
 	case reflect.UnsafePointer:
 	default:
-		return false, fmt.Errorf("(%T) is not a nullable type", nullable)
+		return false, nil
 	}
 
 	defer func() {

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -2798,8 +2798,6 @@ func NotContainsUintptr(t testing.T,
 }
 
 // Nil tests if the passed value is Nil. See also Empty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	if h, ok := t.(testing.Helper); ok {
@@ -2818,8 +2816,6 @@ func Nil(t testing.T, tval interface{}, msg ...interface{}) bool {
 }
 
 // NotNil tests if the passed value is not Nil. See also NotEmpty.
-// Makes sense solely on chan, func, interface, map, pointer, slice value and
-// the zero value type (ie: the nil keyword).
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	if h, ok := t.(testing.Helper); ok {


### PR DESCRIPTION
Address the issue described in https://github.com/rubrikinc/testwell/issues/5, remove the error by `cmp/nil.go` in case of a (potentially incorrectly perceived) not nullable type