### PR TITLE
Expand assertion API and clean up failure-path performance

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -3,7 +3,9 @@
 package assert
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 
 	"github.com/rubrikinc/testwell/internal/cmp"
 	"github.com/rubrikinc/testwell/internal/fail"
@@ -1378,6 +1380,1094 @@ func NotEqualUintptr(t testing.T,
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// GreaterByte tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterByte").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualByte tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualByte").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessByte tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessByte").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualByte tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualByte").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterFloat32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterFloat32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualFloat32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualFloat32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessFloat32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessFloat32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualFloat32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualFloat32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterFloat64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterFloat64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualFloat64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualFloat64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessFloat64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessFloat64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualFloat64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualFloat64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt16 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt16").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt16 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt16").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt16 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt16").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt16 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt16").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt8 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt8").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt8 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt8").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt8 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt8").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt8 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt8").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterRune tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterRune").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualRune tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualRune").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessRune tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessRune").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualRune tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualRune").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterString tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterString").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualString tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualString").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessString tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessString").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualString tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualString").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint16 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint16").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint16 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint16").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint16 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint16").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint16 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint16").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint8 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint8").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint8 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint8").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint8 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint8").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint8 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint8").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUintptr tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUintptr").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUintptr tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUintptr").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUintptr tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUintptr").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUintptr tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUintptr").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
 // EqualTypes tests if `left` and `right` have the same type.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 // Example:
@@ -2655,6 +3745,99 @@ func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// NoError tests if err is nil.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Error, ErrorIs, ErrorAs, ErrorContains.
+func NoError(t testing.T, err error, msg ...interface{}) bool {
+	t.Helper()
+
+	if err == nil {
+		return true
+	}
+	return failTest(t, fail.Failure("NoError").
+		Reason("expected no error, got: %v", err).
+		ExtraMsg(msg...))
+}
+
+// Error tests if err is not nil.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NoError, ErrorIs, ErrorAs, ErrorContains.
+func Error(t testing.T, err error, msg ...interface{}) bool {
+	t.Helper()
+
+	if err != nil {
+		return true
+	}
+	return failTest(t, fail.Failure("Error").
+		Reason("expected an error but got nil").
+		ExtraMsg(msg...))
+}
+
+// ErrorIs tests if errors.Is(err, target) is true.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotErrorIs, NoError, Error.
+func ErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+	t.Helper()
+
+	if errors.Is(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("ErrorIs").
+		Reason("errors.Is(err, target) returned false").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// NotErrorIs tests if errors.Is(err, target) is false.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also ErrorIs, NoError, Error.
+func NotErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+	t.Helper()
+
+	if !errors.Is(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotErrorIs").
+		Reason("errors.Is(err, target) returned true").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// ErrorAs tests if errors.As(err, target) is true.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// target must be a non-nil pointer to either a type that implements error,
+// or to any interface type. See also NotErrorAs.
+func ErrorAs(t testing.T, err error, target interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if errors.As(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("ErrorAs").
+		Reason("errors.As(err, target) returned false").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// ErrorContains tests if err is not nil and err.Error() contains substr.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Error, ErrorIs.
+func ErrorContains(t testing.T, err error, substr string, msg ...interface{}) bool {
+	t.Helper()
+
+	if err != nil && strings.Contains(err.Error(), substr) {
+		return true
+	}
+	failure := fail.Failure("ErrorContains")
+	if err == nil {
+		failure = failure.Reason("expected an error containing %q, got nil", substr)
+	} else {
+		failure = failure.Reason("expected error to contain %q", substr).
+			LeftValue(err.Error()).RightValue(substr)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // Empty tests if the passed value is Empty. A nil container or a container
 // with zero elements are both empty. Uses Go len().
 // Container can be any of Array, Chan, Map, Slice, or String.
@@ -2690,6 +3873,31 @@ func NotEmpty(t testing.T, container interface{}, msg ...interface{}) bool {
 		return true
 	}
 	failure = failure.Reason("`%v` (%T) should not be empty", container, container)
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Len tests if the length of container equals expected. Uses Go len().
+// Container can be any of Array, Chan, Map, Slice, or String.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Len(t testing.T, container interface{}, expected int, msg ...interface{}) bool {
+	t.Helper()
+
+	v := reflect.ValueOf(container)
+	actual := -1
+	switch v.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		actual = v.Len()
+	}
+	if actual == expected {
+		return true
+	}
+	failure := fail.Failure("Len")
+	if actual == -1 {
+		failure = failure.Reason("`%v` (%T) does not support Len", container, container)
+	} else {
+		failure = failure.Reason("expected length %d, got %d", expected, actual).
+			LeftValue(expected).RightValue(actual)
+	}
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
@@ -2733,6 +3941,48 @@ func NotDeepEqual(t testing.T,
 		LeftValue(left).
 		RightValue(right)
 	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Same tests if expected and actual point to the same object (pointer identity).
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	ev := reflect.ValueOf(expected)
+	av := reflect.ValueOf(actual)
+	if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+		return failTest(t, fail.Failure("Same").
+			Reason("both arguments must be pointers").
+			ExtraMsg(msg...))
+	}
+	if ev.Pointer() == av.Pointer() {
+		return true
+	}
+	return failTest(t, fail.Failure("Same").
+		Reason("expected the same pointer").
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
+}
+
+// NotSame tests if expected and actual do not point to the same object.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	ev := reflect.ValueOf(expected)
+	av := reflect.ValueOf(actual)
+	if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+		return failTest(t, fail.Failure("NotSame").
+			Reason("both arguments must be pointers").
+			ExtraMsg(msg...))
+	}
+	if ev.Pointer() != av.Pointer() {
+		return true
+	}
+	return failTest(t, fail.Failure("NotSame").
+		Reason("expected different pointers, got the same").
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
 }
 
 // Failed logs a message and fails the test.
@@ -2781,4 +4031,18 @@ func PanicsWith(t testing.T,
 		return true
 	}
 	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotPanics asserts that the code inside the specified function f does not panic.
+//
+//	assert.NotPanics(t, func(){ Sane() })
+func NotPanics(t testing.T, f func(), msg ...interface{}) bool {
+	t.Helper()
+
+	if funcDidPanic, panicValue := cmp.Panics(f); funcDidPanic {
+		failure := fail.Failure("NotPanics")
+		failure = failure.Reason("Expected function not to panic\n\tPanic value:\t%v", panicValue)
+		return failTest(t, failure.ExtraMsg(msg...))
+	}
+	return true
 }

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -4,7 +4,10 @@ package assert
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/rubrikinc/testwell/internal/cmp"
@@ -3901,6 +3904,52 @@ func Len(t testing.T, container interface{}, expected int, msg ...interface{}) b
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// ElementsMatch tests if `expected` and `actual` contain the same elements
+// regardless of order. Both must be slices or arrays.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Contains, DeepEqual.
+func ElementsMatch(t testing.T,
+	expected interface{},
+	actual interface{},
+	msg ...interface{}) bool {
+	t.Helper()
+
+	ok, err := cmp.ElementsMatch(expected, actual)
+	failure := fail.Failure("ElementsMatch")
+	if err != nil {
+		failure = failure.Error(err)
+	} else if ok {
+		return true
+	} else {
+		failure = failure.Reason("slices contain different elements").
+			LeftValue(expected).RightValue(actual)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotElementsMatch tests if `expected` and `actual` do not contain the same
+// elements (regardless of order). Both must be slices or arrays.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotContains, NotDeepEqual.
+func NotElementsMatch(t testing.T,
+	expected interface{},
+	actual interface{},
+	msg ...interface{}) bool {
+	t.Helper()
+
+	ok, err := cmp.ElementsMatch(expected, actual)
+	failure := fail.Failure("NotElementsMatch")
+	if err != nil {
+		failure = failure.Error(err)
+	} else if !ok {
+		return true
+	} else {
+		failure = failure.Reason("slices contain the same elements").
+			LeftValue(expected).RightValue(actual)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // DeepEqual tests if `left` == `right` using `reflect.DeepEqual`.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 // This is a deep, recursive equality test. See also `Equal`.
@@ -3983,6 +4032,103 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 		Reason("expected different pointers, got the same").
 		LeftValue(expected).RightValue(actual).
 		ExtraMsg(msg...))
+}
+
+// Zero tests if val is the zero value for its type.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+		return true
+	}
+	return failTest(t, fail.Failure("Zero").
+		Reason("expected zero value, got `%v` (%T)", val, val).
+		ExtraMsg(msg...))
+}
+
+// NotZero tests if val is not the zero value for its type.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotZero").
+		Reason("expected non-zero value, got `%v` (%T)", val, val).
+		ExtraMsg(msg...))
+}
+
+// InDelta tests if the absolute difference between expected and actual is
+// less than or equal to delta. Useful for floating-point comparisons.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func InDelta(t testing.T,
+	expected float64,
+	actual float64,
+	delta float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	diff := math.Abs(actual - expected)
+	if diff <= delta {
+		return true
+	}
+	return failTest(t, fail.Failure("InDelta").
+		Reason("|actual - expected| = %v, which exceeds delta %v", diff, delta).
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
+}
+
+// Regexp tests if str matches the given pattern. pattern can be a string or
+// a *regexp.Regexp.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotRegexp.
+func Regexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+	t.Helper()
+
+	rx, err := toRegexp(pattern)
+	if err != nil {
+		return failTest(t, fail.Failure("Regexp").Error(err).ExtraMsg(msg...))
+	}
+	if rx.MatchString(str) {
+		return true
+	}
+	return failTest(t, fail.Failure("Regexp").
+		Reason("expected %q to match pattern %q", str, rx.String()).
+		LeftValue(str).RightValue(rx.String()).
+		ExtraMsg(msg...))
+}
+
+// NotRegexp tests if str does not match the given pattern. pattern can be a
+// string or a *regexp.Regexp.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Regexp.
+func NotRegexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+	t.Helper()
+
+	rx, err := toRegexp(pattern)
+	if err != nil {
+		return failTest(t, fail.Failure("NotRegexp").Error(err).ExtraMsg(msg...))
+	}
+	if !rx.MatchString(str) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotRegexp").
+		Reason("expected %q not to match pattern %q", str, rx.String()).
+		LeftValue(str).RightValue(rx.String()).
+		ExtraMsg(msg...))
+}
+
+func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
+	switch v := pattern.(type) {
+	case string:
+		return regexp.Compile(v)
+	case *regexp.Regexp:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("pattern must be string or *regexp.Regexp, got %T", pattern)
+	}
 }
 
 // Failed logs a message and fails the test.

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -3959,7 +3959,7 @@ func DeepEqual(t testing.T,
 	msg ...interface{}) bool {
 	t.Helper()
 
-	failure := fail.Failure("DeepEqual{")
+	failure := fail.Failure("DeepEqual")
 
 	if reflect.DeepEqual(left, right) {
 		return true
@@ -4041,7 +4041,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
 	t.Helper()
 
-	if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+	if val == nil || reflect.ValueOf(val).IsZero() {
 		return true
 	}
 	return failTest(t, fail.Failure("Zero").
@@ -4054,7 +4054,7 @@ func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
 func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
 	t.Helper()
 
-	if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+	if val != nil && !reflect.ValueOf(val).IsZero() {
 		return true
 	}
 	return failTest(t, fail.Failure("NotZero").
@@ -4138,7 +4138,7 @@ func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
 func Failed(t testing.T, fmtstr string, args ...interface{}) {
 	t.Helper()
 
-	failure := fail.Failure("Custom")
+	failure := fail.Failure("Failed")
 	failure = failure.Reason(fmtstr, args...)
 	failTest(t, failure)
 }
@@ -4150,7 +4150,7 @@ func Panics(t testing.T, f func(), msg ...interface{}) bool {
 	t.Helper()
 
 	if funcDidPanic, _ := cmp.Panics(f); !funcDidPanic {
-		failure := fail.Failure("Panic")
+		failure := fail.Failure("Panics")
 		failure = failure.Reason("Expected function %#v to panic", f)
 		return failTest(t, failure.ExtraMsg(msg...))
 	}
@@ -4168,7 +4168,7 @@ func PanicsWith(t testing.T,
 	t.Helper()
 
 	funcDidPanic, panicValue := cmp.Panics(f)
-	failure := fail.Failure("PanicWithValue")
+	failure := fail.Failure("PanicsWith")
 
 	if !funcDidPanic {
 		failure = failure.Reason("Expected %#v to panic", f)

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -3993,6 +3993,7 @@ func NotDeepEqual(t testing.T,
 }
 
 // Same tests if expected and actual point to the same object (pointer identity).
+// Both arguments must be pointers of the same type.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
 	t.Helper()
@@ -4004,7 +4005,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
 			Reason("both arguments must be pointers").
 			ExtraMsg(msg...))
 	}
-	if ev.Pointer() == av.Pointer() {
+	if reflect.TypeOf(expected) == reflect.TypeOf(actual) && ev.Pointer() == av.Pointer() {
 		return true
 	}
 	return failTest(t, fail.Failure("Same").
@@ -4014,6 +4015,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
 }
 
 // NotSame tests if expected and actual do not point to the same object.
+// Both arguments must be pointers; pointers of different types are never the same.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
 	t.Helper()
@@ -4025,7 +4027,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 			Reason("both arguments must be pointers").
 			ExtraMsg(msg...))
 	}
-	if ev.Pointer() != av.Pointer() {
+	if reflect.TypeOf(expected) != reflect.TypeOf(actual) || ev.Pointer() != av.Pointer() {
 		return true
 	}
 	return failTest(t, fail.Failure("NotSame").

--- a/assert/lib.go
+++ b/assert/lib.go
@@ -9,6 +9,7 @@ import (
 
 func failTest(t testing.T, tf fail.TestFailure) bool {
 	t.Helper()
+	tf = tf.WithStack(2)
 	t.Log(tf.Format("assertion"))
 	t.FailNow()
 	return false

--- a/expect/expect.go
+++ b/expect/expect.go
@@ -3959,7 +3959,7 @@ func DeepEqual(t testing.T,
 	msg ...interface{}) bool {
 	t.Helper()
 
-	failure := fail.Failure("DeepEqual{")
+	failure := fail.Failure("DeepEqual")
 
 	if reflect.DeepEqual(left, right) {
 		return true
@@ -4041,7 +4041,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
 	t.Helper()
 
-	if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+	if val == nil || reflect.ValueOf(val).IsZero() {
 		return true
 	}
 	return failTest(t, fail.Failure("Zero").
@@ -4054,7 +4054,7 @@ func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
 func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
 	t.Helper()
 
-	if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+	if val != nil && !reflect.ValueOf(val).IsZero() {
 		return true
 	}
 	return failTest(t, fail.Failure("NotZero").
@@ -4138,7 +4138,7 @@ func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
 func Failed(t testing.T, fmtstr string, args ...interface{}) {
 	t.Helper()
 
-	failure := fail.Failure("Custom")
+	failure := fail.Failure("Failed")
 	failure = failure.Reason(fmtstr, args...)
 	failTest(t, failure)
 }
@@ -4150,7 +4150,7 @@ func Panics(t testing.T, f func(), msg ...interface{}) bool {
 	t.Helper()
 
 	if funcDidPanic, _ := cmp.Panics(f); !funcDidPanic {
-		failure := fail.Failure("Panic")
+		failure := fail.Failure("Panics")
 		failure = failure.Reason("Expected function %#v to panic", f)
 		return failTest(t, failure.ExtraMsg(msg...))
 	}
@@ -4168,7 +4168,7 @@ func PanicsWith(t testing.T,
 	t.Helper()
 
 	funcDidPanic, panicValue := cmp.Panics(f)
-	failure := fail.Failure("PanicWithValue")
+	failure := fail.Failure("PanicsWith")
 
 	if !funcDidPanic {
 		failure = failure.Reason("Expected %#v to panic", f)

--- a/expect/expect.go
+++ b/expect/expect.go
@@ -3993,6 +3993,7 @@ func NotDeepEqual(t testing.T,
 }
 
 // Same tests if expected and actual point to the same object (pointer identity).
+// Both arguments must be pointers of the same type.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
 	t.Helper()
@@ -4004,7 +4005,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
 			Reason("both arguments must be pointers").
 			ExtraMsg(msg...))
 	}
-	if ev.Pointer() == av.Pointer() {
+	if reflect.TypeOf(expected) == reflect.TypeOf(actual) && ev.Pointer() == av.Pointer() {
 		return true
 	}
 	return failTest(t, fail.Failure("Same").
@@ -4014,6 +4015,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
 }
 
 // NotSame tests if expected and actual do not point to the same object.
+// Both arguments must be pointers; pointers of different types are never the same.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
 	t.Helper()
@@ -4025,7 +4027,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 			Reason("both arguments must be pointers").
 			ExtraMsg(msg...))
 	}
-	if ev.Pointer() != av.Pointer() {
+	if reflect.TypeOf(expected) != reflect.TypeOf(actual) || ev.Pointer() != av.Pointer() {
 		return true
 	}
 	return failTest(t, fail.Failure("NotSame").

--- a/expect/expect.go
+++ b/expect/expect.go
@@ -3,7 +3,9 @@
 package expect
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 
 	"github.com/rubrikinc/testwell/internal/cmp"
 	"github.com/rubrikinc/testwell/internal/fail"
@@ -1378,6 +1380,1094 @@ func NotEqualUintptr(t testing.T,
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// GreaterByte tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterByte").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualByte tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualByte").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessByte tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessByte").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualByte tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualByte").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterFloat32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterFloat32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualFloat32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualFloat32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessFloat32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessFloat32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualFloat32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualFloat32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterFloat64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterFloat64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualFloat64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualFloat64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessFloat64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessFloat64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualFloat64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualFloat64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt16 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt16").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt16 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt16").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt16 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt16").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt16 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt16").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt8 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt8").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt8 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt8").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt8 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt8").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt8 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt8").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterRune tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterRune").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualRune tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualRune").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessRune tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessRune").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualRune tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualRune").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterString tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterString").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualString tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualString").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessString tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessString").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualString tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualString").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint16 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint16").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint16 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint16").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint16 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint16").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint16 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint16").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint8 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint8").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint8 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint8").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint8 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint8").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint8 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint8").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUintptr tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUintptr").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUintptr tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUintptr").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUintptr tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUintptr").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUintptr tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUintptr").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
 // EqualTypes tests if `left` and `right` have the same type.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 // Example:
@@ -2655,6 +3745,99 @@ func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// NoError tests if err is nil.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Error, ErrorIs, ErrorAs, ErrorContains.
+func NoError(t testing.T, err error, msg ...interface{}) bool {
+	t.Helper()
+
+	if err == nil {
+		return true
+	}
+	return failTest(t, fail.Failure("NoError").
+		Reason("expected no error, got: %v", err).
+		ExtraMsg(msg...))
+}
+
+// Error tests if err is not nil.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NoError, ErrorIs, ErrorAs, ErrorContains.
+func Error(t testing.T, err error, msg ...interface{}) bool {
+	t.Helper()
+
+	if err != nil {
+		return true
+	}
+	return failTest(t, fail.Failure("Error").
+		Reason("expected an error but got nil").
+		ExtraMsg(msg...))
+}
+
+// ErrorIs tests if errors.Is(err, target) is true.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotErrorIs, NoError, Error.
+func ErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+	t.Helper()
+
+	if errors.Is(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("ErrorIs").
+		Reason("errors.Is(err, target) returned false").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// NotErrorIs tests if errors.Is(err, target) is false.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also ErrorIs, NoError, Error.
+func NotErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+	t.Helper()
+
+	if !errors.Is(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotErrorIs").
+		Reason("errors.Is(err, target) returned true").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// ErrorAs tests if errors.As(err, target) is true.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// target must be a non-nil pointer to either a type that implements error,
+// or to any interface type. See also NotErrorAs.
+func ErrorAs(t testing.T, err error, target interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if errors.As(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("ErrorAs").
+		Reason("errors.As(err, target) returned false").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// ErrorContains tests if err is not nil and err.Error() contains substr.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Error, ErrorIs.
+func ErrorContains(t testing.T, err error, substr string, msg ...interface{}) bool {
+	t.Helper()
+
+	if err != nil && strings.Contains(err.Error(), substr) {
+		return true
+	}
+	failure := fail.Failure("ErrorContains")
+	if err == nil {
+		failure = failure.Reason("expected an error containing %q, got nil", substr)
+	} else {
+		failure = failure.Reason("expected error to contain %q", substr).
+			LeftValue(err.Error()).RightValue(substr)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // Empty tests if the passed value is Empty. A nil container or a container
 // with zero elements are both empty. Uses Go len().
 // Container can be any of Array, Chan, Map, Slice, or String.
@@ -2690,6 +3873,31 @@ func NotEmpty(t testing.T, container interface{}, msg ...interface{}) bool {
 		return true
 	}
 	failure = failure.Reason("`%v` (%T) should not be empty", container, container)
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Len tests if the length of container equals expected. Uses Go len().
+// Container can be any of Array, Chan, Map, Slice, or String.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Len(t testing.T, container interface{}, expected int, msg ...interface{}) bool {
+	t.Helper()
+
+	v := reflect.ValueOf(container)
+	actual := -1
+	switch v.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		actual = v.Len()
+	}
+	if actual == expected {
+		return true
+	}
+	failure := fail.Failure("Len")
+	if actual == -1 {
+		failure = failure.Reason("`%v` (%T) does not support Len", container, container)
+	} else {
+		failure = failure.Reason("expected length %d, got %d", expected, actual).
+			LeftValue(expected).RightValue(actual)
+	}
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
@@ -2733,6 +3941,48 @@ func NotDeepEqual(t testing.T,
 		LeftValue(left).
 		RightValue(right)
 	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Same tests if expected and actual point to the same object (pointer identity).
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	ev := reflect.ValueOf(expected)
+	av := reflect.ValueOf(actual)
+	if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+		return failTest(t, fail.Failure("Same").
+			Reason("both arguments must be pointers").
+			ExtraMsg(msg...))
+	}
+	if ev.Pointer() == av.Pointer() {
+		return true
+	}
+	return failTest(t, fail.Failure("Same").
+		Reason("expected the same pointer").
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
+}
+
+// NotSame tests if expected and actual do not point to the same object.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	ev := reflect.ValueOf(expected)
+	av := reflect.ValueOf(actual)
+	if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+		return failTest(t, fail.Failure("NotSame").
+			Reason("both arguments must be pointers").
+			ExtraMsg(msg...))
+	}
+	if ev.Pointer() != av.Pointer() {
+		return true
+	}
+	return failTest(t, fail.Failure("NotSame").
+		Reason("expected different pointers, got the same").
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
 }
 
 // Failed logs a message and fails the test.
@@ -2781,4 +4031,18 @@ func PanicsWith(t testing.T,
 		return true
 	}
 	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotPanics asserts that the code inside the specified function f does not panic.
+//
+//	assert.NotPanics(t, func(){ Sane() })
+func NotPanics(t testing.T, f func(), msg ...interface{}) bool {
+	t.Helper()
+
+	if funcDidPanic, panicValue := cmp.Panics(f); funcDidPanic {
+		failure := fail.Failure("NotPanics")
+		failure = failure.Reason("Expected function not to panic\n\tPanic value:\t%v", panicValue)
+		return failTest(t, failure.ExtraMsg(msg...))
+	}
+	return true
 }

--- a/expect/expect.go
+++ b/expect/expect.go
@@ -4,7 +4,10 @@ package expect
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/rubrikinc/testwell/internal/cmp"
@@ -3901,6 +3904,52 @@ func Len(t testing.T, container interface{}, expected int, msg ...interface{}) b
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// ElementsMatch tests if `expected` and `actual` contain the same elements
+// regardless of order. Both must be slices or arrays.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Contains, DeepEqual.
+func ElementsMatch(t testing.T,
+	expected interface{},
+	actual interface{},
+	msg ...interface{}) bool {
+	t.Helper()
+
+	ok, err := cmp.ElementsMatch(expected, actual)
+	failure := fail.Failure("ElementsMatch")
+	if err != nil {
+		failure = failure.Error(err)
+	} else if ok {
+		return true
+	} else {
+		failure = failure.Reason("slices contain different elements").
+			LeftValue(expected).RightValue(actual)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotElementsMatch tests if `expected` and `actual` do not contain the same
+// elements (regardless of order). Both must be slices or arrays.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotContains, NotDeepEqual.
+func NotElementsMatch(t testing.T,
+	expected interface{},
+	actual interface{},
+	msg ...interface{}) bool {
+	t.Helper()
+
+	ok, err := cmp.ElementsMatch(expected, actual)
+	failure := fail.Failure("NotElementsMatch")
+	if err != nil {
+		failure = failure.Error(err)
+	} else if !ok {
+		return true
+	} else {
+		failure = failure.Reason("slices contain the same elements").
+			LeftValue(expected).RightValue(actual)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // DeepEqual tests if `left` == `right` using `reflect.DeepEqual`.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 // This is a deep, recursive equality test. See also `Equal`.
@@ -3983,6 +4032,103 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 		Reason("expected different pointers, got the same").
 		LeftValue(expected).RightValue(actual).
 		ExtraMsg(msg...))
+}
+
+// Zero tests if val is the zero value for its type.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+		return true
+	}
+	return failTest(t, fail.Failure("Zero").
+		Reason("expected zero value, got `%v` (%T)", val, val).
+		ExtraMsg(msg...))
+}
+
+// NotZero tests if val is not the zero value for its type.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotZero").
+		Reason("expected non-zero value, got `%v` (%T)", val, val).
+		ExtraMsg(msg...))
+}
+
+// InDelta tests if the absolute difference between expected and actual is
+// less than or equal to delta. Useful for floating-point comparisons.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func InDelta(t testing.T,
+	expected float64,
+	actual float64,
+	delta float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	diff := math.Abs(actual - expected)
+	if diff <= delta {
+		return true
+	}
+	return failTest(t, fail.Failure("InDelta").
+		Reason("|actual - expected| = %v, which exceeds delta %v", diff, delta).
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
+}
+
+// Regexp tests if str matches the given pattern. pattern can be a string or
+// a *regexp.Regexp.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotRegexp.
+func Regexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+	t.Helper()
+
+	rx, err := toRegexp(pattern)
+	if err != nil {
+		return failTest(t, fail.Failure("Regexp").Error(err).ExtraMsg(msg...))
+	}
+	if rx.MatchString(str) {
+		return true
+	}
+	return failTest(t, fail.Failure("Regexp").
+		Reason("expected %q to match pattern %q", str, rx.String()).
+		LeftValue(str).RightValue(rx.String()).
+		ExtraMsg(msg...))
+}
+
+// NotRegexp tests if str does not match the given pattern. pattern can be a
+// string or a *regexp.Regexp.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Regexp.
+func NotRegexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+	t.Helper()
+
+	rx, err := toRegexp(pattern)
+	if err != nil {
+		return failTest(t, fail.Failure("NotRegexp").Error(err).ExtraMsg(msg...))
+	}
+	if !rx.MatchString(str) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotRegexp").
+		Reason("expected %q not to match pattern %q", str, rx.String()).
+		LeftValue(str).RightValue(rx.String()).
+		ExtraMsg(msg...))
+}
+
+func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
+	switch v := pattern.(type) {
+	case string:
+		return regexp.Compile(v)
+	case *regexp.Regexp:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("pattern must be string or *regexp.Regexp, got %T", pattern)
+	}
 }
 
 // Failed logs a message and fails the test.

--- a/expect/lib.go
+++ b/expect/lib.go
@@ -9,6 +9,7 @@ import (
 
 func failTest(t testing.T, tf fail.TestFailure) bool {
 	t.Helper()
+	tf = tf.WithStack(2)
 	t.Log(tf.Format("check"))
 	t.Fail()
 	return false

--- a/internal/assert.tmpl
+++ b/internal/assert.tmpl
@@ -567,6 +567,7 @@ func NotDeepEqual(t testing.T,
 }
 
 // Same tests if expected and actual point to the same object (pointer identity).
+// Both arguments must be pointers of the same type.
 {{ $msgfmtcomment }}
 func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
     {{- template "helper" "t" }}
@@ -577,7 +578,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
             Reason("both arguments must be pointers").
             ExtraMsg(msg...))
     }
-    if ev.Pointer() == av.Pointer() {
+    if reflect.TypeOf(expected) == reflect.TypeOf(actual) && ev.Pointer() == av.Pointer() {
         return true
     }
     return failTest(t, fail.Failure("Same").
@@ -587,6 +588,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
 }
 
 // NotSame tests if expected and actual do not point to the same object.
+// Both arguments must be pointers; pointers of different types are never the same.
 {{ $msgfmtcomment }}
 func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
     {{- template "helper" "t" }}
@@ -597,7 +599,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
             Reason("both arguments must be pointers").
             ExtraMsg(msg...))
     }
-    if ev.Pointer() != av.Pointer() {
+    if reflect.TypeOf(expected) != reflect.TypeOf(actual) || ev.Pointer() != av.Pointer() {
         return true
     }
     return failTest(t, fail.Failure("NotSame").

--- a/internal/assert.tmpl
+++ b/internal/assert.tmpl
@@ -265,7 +265,7 @@ func NotEqualTypes(t testing.T,
                 failure = failure.Error(err)
             }
         } else if ok {
-            return true;
+            return true
         }
         failure = failure.Reason("`%v` (%T) is not contained in `%v` (%T)",
                         expectedElement, expectedElement, container, container)
@@ -297,7 +297,7 @@ func NotEqualTypes(t testing.T,
                 failure = failure.Error(err)
             }
         } else if !ok {
-            return true;
+            return true
         }
         failure = failure.Reason("`%v` (%T) is contained in `%v` (%T)",
                         expectedElement, expectedElement, container, container)
@@ -534,7 +534,7 @@ func DeepEqual(t testing.T,
         right interface{},
         msg ...interface{}) bool {
     {{- template "helper" "t" }}
-    failure := fail.Failure("DeepEqual{")
+    failure := fail.Failure("DeepEqual")
 
     if reflect.DeepEqual(left, right) {
         return true
@@ -612,7 +612,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 {{ $msgfmtcomment }}
 func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
     {{- template "helper" "t" }}
-    if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+    if val == nil || reflect.ValueOf(val).IsZero() {
         return true
     }
     return failTest(t, fail.Failure("Zero").
@@ -624,7 +624,7 @@ func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
 {{ $msgfmtcomment }}
 func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
     {{- template "helper" "t" }}
-    if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+    if val != nil && !reflect.ValueOf(val).IsZero() {
         return true
     }
     return failTest(t, fail.Failure("NotZero").
@@ -704,7 +704,7 @@ func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
 // fmtstr and args follows the `fmt.Printf()` format.
 func Failed(t testing.T, fmtstr string, args ...interface{}) {
     {{- template "helper" "t" }}
-    failure := fail.Failure("Custom")
+    failure := fail.Failure("Failed")
     failure = failure.Reason(fmtstr, args...)
     failTest(t, failure)
 }
@@ -715,7 +715,7 @@ func Panics(t testing.T, f func(), msg ...interface{}) bool {
 	{{- template "helper" "t" }}
 
 	if funcDidPanic, _ := cmp.Panics(f); !funcDidPanic {
-		failure := fail.Failure("Panic")
+		failure := fail.Failure("Panics")
 		failure = failure.Reason("Expected function %#v to panic", f)
 		return failTest(t, failure.ExtraMsg(msg...))
 	}
@@ -731,7 +731,7 @@ func PanicsWith(t testing.T,
         msg ...interface{}) bool {
 	{{- template "helper" "t" }}
 	funcDidPanic, panicValue := cmp.Panics(f)
-	failure := fail.Failure("PanicWithValue")
+	failure := fail.Failure("PanicsWith")
 
 	if !funcDidPanic {
 		failure = failure.Reason("Expected %#v to panic", f)

--- a/internal/assert.tmpl
+++ b/internal/assert.tmpl
@@ -1,7 +1,9 @@
 package {{ .Package }}
 
 import (
+    "errors"
     "reflect"
+    "strings"
 
     "github.com/rubrikinc/testwell/internal/cmp"
     "github.com/rubrikinc/testwell/internal/fail"
@@ -121,6 +123,72 @@ func False(t testing.T, tval bool, msg ...interface{}) bool {
         failure = failure.Reason("values should not be equal").
 			LeftValue(left).RightValue(right)
         return failTest(t, failure.ExtraMsg(msg...))
+    }
+{{ end }}
+
+{{ range $T := OrderedTypes }}
+    // Greater{{ $T.N }} tests if `left` is strictly greater than `right`.
+    {{ $msgfmtcomment }}
+    func Greater{{ $T.N }}(t testing.T,
+            left {{ $T.T }},
+            right {{ $T.T }},
+            msg ...interface{}) bool {
+        {{- template "helper" "t" }}
+        if left > right {
+            return true
+        }
+        return failTest(t, fail.Failure("Greater{{ $T.N }}").
+            Reason("expected left > right").
+            LeftValue(left).RightValue(right).
+            ExtraMsg(msg...))
+    }
+
+    // GreaterOrEqual{{ $T.N }} tests if `left` is greater than or equal to `right`.
+    {{ $msgfmtcomment }}
+    func GreaterOrEqual{{ $T.N }}(t testing.T,
+            left {{ $T.T }},
+            right {{ $T.T }},
+            msg ...interface{}) bool {
+        {{- template "helper" "t" }}
+        if left >= right {
+            return true
+        }
+        return failTest(t, fail.Failure("GreaterOrEqual{{ $T.N }}").
+            Reason("expected left >= right").
+            LeftValue(left).RightValue(right).
+            ExtraMsg(msg...))
+    }
+
+    // Less{{ $T.N }} tests if `left` is strictly less than `right`.
+    {{ $msgfmtcomment }}
+    func Less{{ $T.N }}(t testing.T,
+            left {{ $T.T }},
+            right {{ $T.T }},
+            msg ...interface{}) bool {
+        {{- template "helper" "t" }}
+        if left < right {
+            return true
+        }
+        return failTest(t, fail.Failure("Less{{ $T.N }}").
+            Reason("expected left < right").
+            LeftValue(left).RightValue(right).
+            ExtraMsg(msg...))
+    }
+
+    // LessOrEqual{{ $T.N }} tests if `left` is less than or equal to `right`.
+    {{ $msgfmtcomment }}
+    func LessOrEqual{{ $T.N }}(t testing.T,
+            left {{ $T.T }},
+            right {{ $T.T }},
+            msg ...interface{}) bool {
+        {{- template "helper" "t" }}
+        if left <= right {
+            return true
+        }
+        return failTest(t, fail.Failure("LessOrEqual{{ $T.N }}").
+            Reason("expected left <= right").
+            LeftValue(left).RightValue(right).
+            ExtraMsg(msg...))
     }
 {{ end }}
 
@@ -264,6 +332,93 @@ func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
     return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// NoError tests if err is nil.
+{{ $msgfmtcomment }}
+// See also Error, ErrorIs, ErrorAs, ErrorContains.
+func NoError(t testing.T, err error, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if err == nil {
+        return true
+    }
+    return failTest(t, fail.Failure("NoError").
+        Reason("expected no error, got: %v", err).
+        ExtraMsg(msg...))
+}
+
+// Error tests if err is not nil.
+{{ $msgfmtcomment }}
+// See also NoError, ErrorIs, ErrorAs, ErrorContains.
+func Error(t testing.T, err error, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if err != nil {
+        return true
+    }
+    return failTest(t, fail.Failure("Error").
+        Reason("expected an error but got nil").
+        ExtraMsg(msg...))
+}
+
+// ErrorIs tests if errors.Is(err, target) is true.
+{{ $msgfmtcomment }}
+// See also NotErrorIs, NoError, Error.
+func ErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if errors.Is(err, target) {
+        return true
+    }
+    return failTest(t, fail.Failure("ErrorIs").
+        Reason("errors.Is(err, target) returned false").
+        LeftValue(err).RightValue(target).
+        ExtraMsg(msg...))
+}
+
+// NotErrorIs tests if errors.Is(err, target) is false.
+{{ $msgfmtcomment }}
+// See also ErrorIs, NoError, Error.
+func NotErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if !errors.Is(err, target) {
+        return true
+    }
+    return failTest(t, fail.Failure("NotErrorIs").
+        Reason("errors.Is(err, target) returned true").
+        LeftValue(err).RightValue(target).
+        ExtraMsg(msg...))
+}
+
+// ErrorAs tests if errors.As(err, target) is true.
+{{ $msgfmtcomment }}
+// target must be a non-nil pointer to either a type that implements error,
+// or to any interface type. See also NotErrorAs.
+func ErrorAs(t testing.T, err error, target interface{}, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if errors.As(err, target) {
+        return true
+    }
+    return failTest(t, fail.Failure("ErrorAs").
+        Reason("errors.As(err, target) returned false").
+        LeftValue(err).RightValue(target).
+        ExtraMsg(msg...))
+}
+
+// ErrorContains tests if err is not nil and err.Error() contains substr.
+{{ $msgfmtcomment }}
+// See also Error, ErrorIs.
+func ErrorContains(t testing.T, err error, substr string, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if err != nil && strings.Contains(err.Error(), substr) {
+        return true
+    }
+    failure := fail.Failure("ErrorContains")
+    if err == nil {
+        failure = failure.Reason("expected an error containing %q, got nil", substr)
+    } else {
+        failure = failure.Reason("expected error to contain %q", substr).
+            LeftValue(err.Error()).RightValue(substr)
+    }
+    return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // Empty tests if the passed value is Empty. A nil container or a container
 // with zero elements are both empty. Uses Go len().
 // Container can be any of Array, Chan, Map, Slice, or String.
@@ -297,6 +452,30 @@ func NotEmpty(t testing.T, container interface{}, msg ...interface{}) bool {
         return true
     }
     failure = failure.Reason("`%v` (%T) should not be empty", container, container)
+    return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Len tests if the length of container equals expected. Uses Go len().
+// Container can be any of Array, Chan, Map, Slice, or String.
+{{ $msgfmtcomment }}
+func Len(t testing.T, container interface{}, expected int, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    v := reflect.ValueOf(container)
+    actual := -1
+    switch v.Kind() {
+    case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+        actual = v.Len()
+    }
+    if actual == expected {
+        return true
+    }
+    failure := fail.Failure("Len")
+    if actual == -1 {
+        failure = failure.Reason("`%v` (%T) does not support Len", container, container)
+    } else {
+        failure = failure.Reason("expected length %d, got %d", expected, actual).
+            LeftValue(expected).RightValue(actual)
+    }
     return failTest(t, failure.ExtraMsg(msg...))
 }
 
@@ -338,6 +517,46 @@ func NotDeepEqual(t testing.T,
 			LeftValue(left).
 			RightValue(right)
     return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Same tests if expected and actual point to the same object (pointer identity).
+{{ $msgfmtcomment }}
+func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    ev := reflect.ValueOf(expected)
+    av := reflect.ValueOf(actual)
+    if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+        return failTest(t, fail.Failure("Same").
+            Reason("both arguments must be pointers").
+            ExtraMsg(msg...))
+    }
+    if ev.Pointer() == av.Pointer() {
+        return true
+    }
+    return failTest(t, fail.Failure("Same").
+        Reason("expected the same pointer").
+        LeftValue(expected).RightValue(actual).
+        ExtraMsg(msg...))
+}
+
+// NotSame tests if expected and actual do not point to the same object.
+{{ $msgfmtcomment }}
+func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    ev := reflect.ValueOf(expected)
+    av := reflect.ValueOf(actual)
+    if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+        return failTest(t, fail.Failure("NotSame").
+            Reason("both arguments must be pointers").
+            ExtraMsg(msg...))
+    }
+    if ev.Pointer() != av.Pointer() {
+        return true
+    }
+    return failTest(t, fail.Failure("NotSame").
+        Reason("expected different pointers, got the same").
+        LeftValue(expected).RightValue(actual).
+        ExtraMsg(msg...))
 }
 
 // Failed logs a message and fails the test.
@@ -382,4 +601,16 @@ func PanicsWith(t testing.T,
 		return true
 	}
 	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotPanics asserts that the code inside the specified function f does not panic.
+//   assert.NotPanics(t, func(){ Sane() })
+func NotPanics(t testing.T, f func(), msg ...interface{}) bool {
+	{{- template "helper" "t" }}
+	if funcDidPanic, panicValue := cmp.Panics(f); funcDidPanic {
+		failure := fail.Failure("NotPanics")
+		failure = failure.Reason("Expected function not to panic\n\tPanic value:\t%v", panicValue)
+		return failTest(t, failure.ExtraMsg(msg...))
+	}
+	return true
 }

--- a/internal/assert.tmpl
+++ b/internal/assert.tmpl
@@ -2,7 +2,10 @@ package {{ .Package }}
 
 import (
     "errors"
+    "fmt"
+    "math"
     "reflect"
+    "regexp"
     "strings"
 
     "github.com/rubrikinc/testwell/internal/cmp"
@@ -479,6 +482,50 @@ func Len(t testing.T, container interface{}, expected int, msg ...interface{}) b
     return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// ElementsMatch tests if `expected` and `actual` contain the same elements
+// regardless of order. Both must be slices or arrays.
+{{ $msgfmtcomment }}
+// See also Contains, DeepEqual.
+func ElementsMatch(t testing.T,
+        expected interface{},
+        actual interface{},
+        msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    ok, err := cmp.ElementsMatch(expected, actual)
+    failure := fail.Failure("ElementsMatch")
+    if err != nil {
+        failure = failure.Error(err)
+    } else if ok {
+        return true
+    } else {
+        failure = failure.Reason("slices contain different elements").
+            LeftValue(expected).RightValue(actual)
+    }
+    return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotElementsMatch tests if `expected` and `actual` do not contain the same
+// elements (regardless of order). Both must be slices or arrays.
+{{ $msgfmtcomment }}
+// See also NotContains, NotDeepEqual.
+func NotElementsMatch(t testing.T,
+        expected interface{},
+        actual interface{},
+        msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    ok, err := cmp.ElementsMatch(expected, actual)
+    failure := fail.Failure("NotElementsMatch")
+    if err != nil {
+        failure = failure.Error(err)
+    } else if !ok {
+        return true
+    } else {
+        failure = failure.Reason("slices contain the same elements").
+            LeftValue(expected).RightValue(actual)
+    }
+    return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // DeepEqual tests if `left` == `right` using `reflect.DeepEqual`.
 {{ $msgfmtcomment }}
 // This is a deep, recursive equality test. See also `Equal`.
@@ -557,6 +604,98 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
         Reason("expected different pointers, got the same").
         LeftValue(expected).RightValue(actual).
         ExtraMsg(msg...))
+}
+
+// Zero tests if val is the zero value for its type.
+{{ $msgfmtcomment }}
+func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+        return true
+    }
+    return failTest(t, fail.Failure("Zero").
+        Reason("expected zero value, got `%v` (%T)", val, val).
+        ExtraMsg(msg...))
+}
+
+// NotZero tests if val is not the zero value for its type.
+{{ $msgfmtcomment }}
+func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+        return true
+    }
+    return failTest(t, fail.Failure("NotZero").
+        Reason("expected non-zero value, got `%v` (%T)", val, val).
+        ExtraMsg(msg...))
+}
+
+// InDelta tests if the absolute difference between expected and actual is
+// less than or equal to delta. Useful for floating-point comparisons.
+{{ $msgfmtcomment }}
+func InDelta(t testing.T,
+        expected float64,
+        actual float64,
+        delta float64,
+        msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    diff := math.Abs(actual - expected)
+    if diff <= delta {
+        return true
+    }
+    return failTest(t, fail.Failure("InDelta").
+        Reason("|actual - expected| = %v, which exceeds delta %v", diff, delta).
+        LeftValue(expected).RightValue(actual).
+        ExtraMsg(msg...))
+}
+
+// Regexp tests if str matches the given pattern. pattern can be a string or
+// a *regexp.Regexp.
+{{ $msgfmtcomment }}
+// See also NotRegexp.
+func Regexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    rx, err := toRegexp(pattern)
+    if err != nil {
+        return failTest(t, fail.Failure("Regexp").Error(err).ExtraMsg(msg...))
+    }
+    if rx.MatchString(str) {
+        return true
+    }
+    return failTest(t, fail.Failure("Regexp").
+        Reason("expected %q to match pattern %q", str, rx.String()).
+        LeftValue(str).RightValue(rx.String()).
+        ExtraMsg(msg...))
+}
+
+// NotRegexp tests if str does not match the given pattern. pattern can be a
+// string or a *regexp.Regexp.
+{{ $msgfmtcomment }}
+// See also Regexp.
+func NotRegexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+    {{- template "helper" "t" }}
+    rx, err := toRegexp(pattern)
+    if err != nil {
+        return failTest(t, fail.Failure("NotRegexp").Error(err).ExtraMsg(msg...))
+    }
+    if !rx.MatchString(str) {
+        return true
+    }
+    return failTest(t, fail.Failure("NotRegexp").
+        Reason("expected %q not to match pattern %q", str, rx.String()).
+        LeftValue(str).RightValue(rx.String()).
+        ExtraMsg(msg...))
+}
+
+func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
+    switch v := pattern.(type) {
+    case string:
+        return regexp.Compile(v)
+    case *regexp.Regexp:
+        return v, nil
+    default:
+        return nil, fmt.Errorf("pattern must be string or *regexp.Regexp, got %T", pattern)
+    }
 }
 
 // Failed logs a message and fails the test.

--- a/internal/cmp/elements.go
+++ b/internal/cmp/elements.go
@@ -1,0 +1,51 @@
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ElementsMatch returns true if listA and listB contain the same elements
+// regardless of order. Both must be slices or arrays.
+func ElementsMatch(listA, listB interface{}) (bool, error) {
+	aVal := reflect.ValueOf(listA)
+	bVal := reflect.ValueOf(listB)
+
+	aKind := aVal.Kind()
+	bKind := bVal.Kind()
+
+	if aKind != reflect.Slice && aKind != reflect.Array {
+		return false, fmt.Errorf("first argument must be a slice or array, got %T", listA)
+	}
+	if bKind != reflect.Slice && bKind != reflect.Array {
+		return false, fmt.Errorf("second argument must be a slice or array, got %T", listB)
+	}
+
+	aLen := aVal.Len()
+	bLen := bVal.Len()
+
+	if aLen != bLen {
+		return false, nil
+	}
+	if aLen == 0 {
+		return true, nil
+	}
+
+	// O(n²) via DeepEqual — correct for all types including non-comparable ones.
+	matched := make([]bool, bLen)
+	for i := 0; i < aLen; i++ {
+		aElem := aVal.Index(i).Interface()
+		found := false
+		for j := 0; j < bLen; j++ {
+			if !matched[j] && reflect.DeepEqual(aElem, bVal.Index(j).Interface()) {
+				matched[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/internal/cmp/empty.go
+++ b/internal/cmp/empty.go
@@ -5,17 +5,13 @@ import (
 	"reflect"
 )
 
-// Empty returns ok=true if `container is empty. A nil pointer to a container
+// Empty returns ok=true if `container` is empty. A nil pointer to a container
 // type is empty. A container with zero element is empty.
 func Empty(container interface{}) (ok bool, err error) {
 	containerVal := reflect.ValueOf(container)
 
 	switch containerVal.Kind() {
-	case reflect.Array:
-	case reflect.Chan:
-	case reflect.Map:
-	case reflect.Slice:
-	case reflect.String:
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
 	default:
 		return false, fmt.Errorf("(%T) is not a container type", container)
 	}

--- a/internal/cmp/nil.go
+++ b/internal/cmp/nil.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-// Nil returns ok=true if `nullable is a nullable type or the zero value type.
+// Nil returns ok=true if `nullable` is a nullable type or the zero value type.
 func Nil(nullable interface{}) (ok bool, err error) {
 	nullableVal := reflect.ValueOf(nullable)
 
@@ -14,13 +14,8 @@ func Nil(nullable interface{}) (ok bool, err error) {
 	}
 
 	switch nullableVal.Kind() {
-	case reflect.Chan:
-	case reflect.Func:
-	case reflect.Interface:
-	case reflect.Map:
-	case reflect.Ptr:
-	case reflect.Slice:
-	case reflect.UnsafePointer:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
 	default:
 		return false, nil
 	}

--- a/internal/codegen/main.go
+++ b/internal/codegen/main.go
@@ -54,6 +54,19 @@ func primitiveTypes(accs ...types) types {
 	return uniqAndOrdered(accs...)
 }
 
+func orderedTypes(accs ...types) types {
+	accs = append(accs, strings2types([]string{
+		"int", "uint",
+		"int8", "uint8",
+		"int16", "uint16",
+		"int32", "uint32",
+		"int64", "uint64",
+		"float32", "float64",
+		"byte", "uintptr", "rune", "string",
+	}))
+	return uniqAndOrdered(accs...)
+}
+
 type tmplData struct {
 	Package string
 }
@@ -114,7 +127,8 @@ func main() {
 			accs = append(accs, types{typeInfo{N: "", T: "interface{}"}})
 			return uniqAndOrdered(accs...)
 		},
-		"Capitalize": strings.Title,
+		"OrderedTypes": orderedTypes,
+		"Capitalize":   strings.Title,
 	})
 
 	outputFilename := fmt.Sprintf("%s.go", *flagPkg)

--- a/internal/codegen/main.go
+++ b/internal/codegen/main.go
@@ -105,10 +105,20 @@ func uniqAndOrdered(accs ...types) types {
 	return r
 }
 
+// capitalize uppercases the first ASCII byte of s. Suitable for the lowercase
+// Go type identifiers we feed it ("int", "uint8", "complex64", "error", ...);
+// not a general-purpose replacement for strings.Title.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
 func strings2types(ss []string) types {
 	r := make(types, 0, len(ss))
 	for _, s := range ss {
-		r = append(r, typeInfo{T: s, N: strings.Title(s)})
+		r = append(r, typeInfo{T: s, N: capitalize(s)})
 	}
 	return r
 }
@@ -128,7 +138,7 @@ func main() {
 			return uniqAndOrdered(accs...)
 		},
 		"OrderedTypes": orderedTypes,
-		"Capitalize":   strings.Title,
+		"Capitalize":   capitalize,
 	})
 
 	outputFilename := fmt.Sprintf("%s.go", *flagPkg)

--- a/internal/fail/fail.go
+++ b/internal/fail/fail.go
@@ -7,47 +7,86 @@ import (
 	"strings"
 )
 
-// TestFailure is a builder of test failure message with stacktrace.
+// valueFormat selects how a value attached to a TestFailure is rendered.
+type valueFormat int8
+
+const (
+	valueUnset valueFormat = iota
+	valueAsValue
+	valueAsType
+)
+
+// valueSlot defers rendering of a left/right value until Format runs.
+// Test assertions often deal with large structs/maps; building the
+// string only at Format time keeps the success path allocation-free
+// and isolates presentation from data capture.
+type valueSlot struct {
+	Format valueFormat
+	Value  interface{}
+}
+
+func (s valueSlot) String() string {
+	switch s.Format {
+	case valueAsValue:
+		return fmt.Sprintf("`%+v` (%T)", s.Value, s.Value)
+	case valueAsType:
+		return fmt.Sprintf("(%T)", s.Value)
+	}
+	return ""
+}
+
+// TestFailure is a builder of test failure messages with stacktrace.
+// Failure() returns a zero-cost builder; the stack is captured lazily
+// by WithStack at the failure path (see failTest in each package).
 type TestFailure struct {
 	Name        string
 	Stack       []uintptr
-	LeftStr     string
-	RightStr    string
+	Left        valueSlot
+	Right       valueSlot
 	ReasonStr   string
 	HintStr     string
 	ExtraMsgStr string
 	Err         error
 }
 
-// Failure instantiate a new msg builder with a snapshot of call stack.
+// Failure returns a new TestFailure for the given assertion name.
+// It allocates only the struct itself; stack capture is deferred to
+// WithStack so the success path of every assertion stays cheap.
 func Failure(assertion string) TestFailure {
+	return TestFailure{Name: assertion}
+}
+
+// WithStack records a stack trace into tf, skipping `skip` frames above
+// WithStack's caller. Pass skip=0 to start the trace at WithStack's
+// immediate caller.
+func (tf TestFailure) WithStack(skip int) TestFailure {
 	stack := make([]uintptr, 32)
-	stackSize := runtime.Callers(3, stack)
-	stack = stack[:stackSize]
-	return TestFailure{Name: assertion, Stack: stack}
+	n := runtime.Callers(2+skip, stack)
+	tf.Stack = stack[:n]
+	return tf
 }
 
 // LeftValue used for the test.
 func (tf TestFailure) LeftValue(left interface{}) TestFailure {
-	tf.LeftStr = fmt.Sprintf("`%+v` (%T)", left, left)
+	tf.Left = valueSlot{Format: valueAsValue, Value: left}
 	return tf
 }
 
 // RightValue used for the test.
 func (tf TestFailure) RightValue(right interface{}) TestFailure {
-	tf.RightStr = fmt.Sprintf("`%+v` (%T)", right, right)
+	tf.Right = valueSlot{Format: valueAsValue, Value: right}
 	return tf
 }
 
 // LeftType used for the test.
 func (tf TestFailure) LeftType(left interface{}) TestFailure {
-	tf.LeftStr = fmt.Sprintf("(%T)", left)
+	tf.Left = valueSlot{Format: valueAsType, Value: left}
 	return tf
 }
 
 // RightType used for the test.
 func (tf TestFailure) RightType(right interface{}) TestFailure {
-	tf.RightStr = fmt.Sprintf("(%T)", right)
+	tf.Right = valueSlot{Format: valueAsType, Value: right}
 	return tf
 }
 
@@ -100,6 +139,9 @@ func reverseSliceOfStrings(s []string) {
 }
 
 func (tf TestFailure) formattedFrames() []string {
+	if len(tf.Stack) == 0 {
+		return nil
+	}
 	r := make([]string, 0, len(tf.Stack))
 	frames := runtime.CallersFrames(tf.Stack)
 	for {
@@ -119,20 +161,23 @@ func (tf TestFailure) formattedFrames() []string {
 
 // Format returns a properly formatted test failure message with a stacktrace.
 func (tf TestFailure) Format(failType string) string {
+	leftStr := tf.Left.String()
+	rightStr := tf.Right.String()
+
 	r := fmt.Sprintf("%s %s failed:\nTrace (most recent last):\n  %s",
 		tf.Name, failType, strings.Join(tf.formattedFrames(), "\n  "))
 
 	if tf.Err != nil {
-		if tf.LeftStr != "" && tf.RightStr != "" {
-			r = fmt.Sprintf("%s\n Left: %s\nRight: %s", r, tf.LeftStr, tf.RightStr)
+		if leftStr != "" && rightStr != "" {
+			r = fmt.Sprintf("%s\n Left: %s\nRight: %s", r, leftStr, rightStr)
 		}
 		r = fmt.Sprintf("%s\nError: %s", r, tf.Err.Error())
 		if tf.HintStr != "" {
 			r = fmt.Sprintf("%s\n Hint: %s", r, tf.HintStr)
 		}
 	} else {
-		if tf.LeftStr != "" && tf.RightStr != "" {
-			r = fmt.Sprintf("%s\n  Left: %s\n Right: %s", r, tf.LeftStr, tf.RightStr)
+		if leftStr != "" && rightStr != "" {
+			r = fmt.Sprintf("%s\n  Left: %s\n Right: %s", r, leftStr, rightStr)
 		}
 		r = fmt.Sprintf("%s\nReason: %s", r, tf.ReasonStr)
 		if tf.HintStr != "" {

--- a/internal/tests/assert_test.go
+++ b/internal/tests/assert_test.go
@@ -1,7 +1,10 @@
 package tests
 
 import (
+	"errors"
 	"fmt"
+	"math"
+	"regexp"
 	"testing"
 )
 
@@ -416,4 +419,513 @@ func TestFailed(t *testing.T) {
 	if wt.LastFailure().ReasonStr != "foo 42" {
 		t.Errorf("obvious test2 failed")
 	}
+}
+
+// --- Error assertions ---
+
+var errSentinel = errors.New("sentinel")
+
+type myErr struct{ msg string }
+
+func (e *myErr) Error() string { return e.msg }
+
+func TestNoError(t *testing.T) {
+	cases := []struct {
+		Name string
+		Err  error
+		O    bool
+	}{
+		{"nil", nil, true},
+		{"non-nil", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if NoError(wt, tc.Err) != tc.O {
+				t.Errorf("NoError(%v) should be %v", tc.Err, tc.O)
+			}
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	cases := []struct {
+		Name string
+		Err  error
+		O    bool
+	}{
+		{"nil", nil, false},
+		{"non-nil", errors.New("boom"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if Error(wt, tc.Err) != tc.O {
+				t.Errorf("Error(%v) should be %v", tc.Err, tc.O)
+			}
+		})
+	}
+}
+
+func TestErrorIs(t *testing.T) {
+	wrapped := fmt.Errorf("context: %w", errSentinel)
+	cases := []struct {
+		Name   string
+		Err    error
+		Target error
+		O      bool
+	}{
+		{"identical", errSentinel, errSentinel, true},
+		{"wrapped matches", wrapped, errSentinel, true},
+		{"unrelated", errors.New("other"), errSentinel, false},
+		{"nil err non-nil target", nil, errSentinel, false},
+		{"both nil", nil, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if ErrorIs(wt, tc.Err, tc.Target) != tc.O {
+				t.Errorf("ErrorIs(%v, %v) should be %v", tc.Err, tc.Target, tc.O)
+			}
+		})
+	}
+}
+
+func TestNotErrorIs(t *testing.T) {
+	wrapped := fmt.Errorf("context: %w", errSentinel)
+	cases := []struct {
+		Name   string
+		Err    error
+		Target error
+		O      bool
+	}{
+		{"identical", errSentinel, errSentinel, false},
+		{"wrapped matches", wrapped, errSentinel, false},
+		{"unrelated", errors.New("other"), errSentinel, true},
+		{"nil err non-nil target", nil, errSentinel, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if NotErrorIs(wt, tc.Err, tc.Target) != tc.O {
+				t.Errorf("NotErrorIs(%v, %v) should be %v", tc.Err, tc.Target, tc.O)
+			}
+		})
+	}
+}
+
+func TestErrorAs(t *testing.T) {
+	base := &myErr{msg: "boom"}
+	wrapped := fmt.Errorf("context: %w", base)
+
+	t.Run("matches in wrapped chain", func(t *testing.T) {
+		wt := wrap(t)
+		var target *myErr
+		if !ErrorAs(wt, wrapped, &target) {
+			t.Errorf("ErrorAs should find *myErr in wrapped chain")
+		}
+		if target == nil || target.msg != "boom" {
+			t.Errorf("target should be populated, got %v", target)
+		}
+	})
+
+	t.Run("type not in chain", func(t *testing.T) {
+		wt := wrap(t)
+		var target *myErr
+		if ErrorAs(wt, errors.New("plain"), &target) {
+			t.Errorf("ErrorAs should not find *myErr in plain error")
+		}
+	})
+
+	t.Run("nil err", func(t *testing.T) {
+		wt := wrap(t)
+		var target *myErr
+		if ErrorAs(wt, nil, &target) {
+			t.Errorf("ErrorAs should fail on nil err")
+		}
+	})
+}
+
+func TestErrorContains(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Err    error
+		Substr string
+		O      bool
+	}{
+		{"contains substring", errors.New("disk full: out of space"), "out of space", true},
+		{"empty substring matches non-nil", errors.New("anything"), "", true},
+		{"no match", errors.New("anything"), "missing", false},
+		{"nil err", nil, "anything", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if ErrorContains(wt, tc.Err, tc.Substr) != tc.O {
+				t.Errorf("ErrorContains(%v, %q) should be %v", tc.Err, tc.Substr, tc.O)
+			}
+		})
+	}
+}
+
+// --- Ordering assertions (one representative per operator) ---
+
+func TestGreaterInt(t *testing.T) {
+	cases := []struct {
+		L, R int
+		O    bool
+	}{
+		{2, 1, true},
+		{1, 1, false},
+		{1, 2, false},
+		{-1, -2, true},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d>%d", tc.L, tc.R), func(t *testing.T) {
+			wt := wrap(t)
+			if GreaterInt(wt, tc.L, tc.R) != tc.O {
+				t.Errorf("GreaterInt(%d, %d) should be %v", tc.L, tc.R, tc.O)
+			}
+		})
+	}
+}
+
+func TestGreaterOrEqualFloat64(t *testing.T) {
+	cases := []struct {
+		L, R float64
+		O    bool
+	}{
+		{2.0, 1.0, true},
+		{1.0, 1.0, true},
+		{1.0, 2.0, false},
+		{math.NaN(), 1.0, false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v>=%v", tc.L, tc.R), func(t *testing.T) {
+			wt := wrap(t)
+			if GreaterOrEqualFloat64(wt, tc.L, tc.R) != tc.O {
+				t.Errorf("GreaterOrEqualFloat64(%v, %v) should be %v", tc.L, tc.R, tc.O)
+			}
+		})
+	}
+}
+
+func TestLessString(t *testing.T) {
+	cases := []struct {
+		L, R string
+		O    bool
+	}{
+		{"apple", "banana", true},
+		{"banana", "apple", false},
+		{"apple", "apple", false},
+		{"", "a", true},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%q<%q", tc.L, tc.R), func(t *testing.T) {
+			wt := wrap(t)
+			if LessString(wt, tc.L, tc.R) != tc.O {
+				t.Errorf("LessString(%q, %q) should be %v", tc.L, tc.R, tc.O)
+			}
+		})
+	}
+}
+
+func TestLessOrEqualInt(t *testing.T) {
+	cases := []struct {
+		L, R int
+		O    bool
+	}{
+		{1, 2, true},
+		{1, 1, true},
+		{2, 1, false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d<=%d", tc.L, tc.R), func(t *testing.T) {
+			wt := wrap(t)
+			if LessOrEqualInt(wt, tc.L, tc.R) != tc.O {
+				t.Errorf("LessOrEqualInt(%d, %d) should be %v", tc.L, tc.R, tc.O)
+			}
+		})
+	}
+}
+
+// --- Collection assertions ---
+
+func TestLen(t *testing.T) {
+	ch := make(chan int, 5)
+	ch <- 1
+	ch <- 2
+	cases := []struct {
+		Name      string
+		Container interface{}
+		Expected  int
+		O         bool
+	}{
+		{"slice match", []int{1, 2, 3}, 3, true},
+		{"slice mismatch", []int{1, 2, 3}, 2, false},
+		{"empty slice", []int{}, 0, true},
+		{"nil slice", []int(nil), 0, true},
+		{"array", [3]int{1, 2, 3}, 3, true},
+		{"map", map[string]int{"a": 1, "b": 2}, 2, true},
+		{"string bytes not runes", "héllo", 6, true},
+		{"channel buffered", ch, 2, true},
+		{"non-container int", 42, 0, false},
+		{"nil interface", nil, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if Len(wt, tc.Container, tc.Expected) != tc.O {
+				t.Errorf("Len(%v, %d) should be %v", tc.Container, tc.Expected, tc.O)
+			}
+		})
+	}
+}
+
+func TestElementsMatch(t *testing.T) {
+	cases := []struct {
+		Name string
+		A, B interface{}
+		O    bool
+	}{
+		{"identical order", []int{1, 2, 3}, []int{1, 2, 3}, true},
+		{"different order", []int{1, 2, 3}, []int{3, 1, 2}, true},
+		{"both empty", []int{}, []int{}, true},
+		{"different lengths", []int{1, 2, 3}, []int{1, 2}, false},
+		{"different elements", []int{1, 2, 3}, []int{1, 2, 4}, false},
+		{"duplicates different multiplicity", []int{1, 1, 2}, []int{1, 2, 2}, false},
+		{"duplicates same multiplicity", []int{1, 2, 1}, []int{2, 1, 1}, true},
+		{"strings", []string{"a", "b"}, []string{"b", "a"}, true},
+		{"non-slice arg", 42, []int{}, false},
+		{"cross-type", []int{1}, []int64{1}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if ElementsMatch(wt, tc.A, tc.B) != tc.O {
+				t.Errorf("ElementsMatch(%v, %v) should be %v", tc.A, tc.B, tc.O)
+			}
+		})
+	}
+}
+
+func TestNotElementsMatch(t *testing.T) {
+	cases := []struct {
+		Name string
+		A, B interface{}
+		O    bool
+	}{
+		{"different order match", []int{1, 2, 3}, []int{3, 1, 2}, false},
+		{"different elements", []int{1, 2, 3}, []int{1, 2, 4}, true},
+		{"non-slice arg", 42, []int{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if NotElementsMatch(wt, tc.A, tc.B) != tc.O {
+				t.Errorf("NotElementsMatch(%v, %v) should be %v", tc.A, tc.B, tc.O)
+			}
+		})
+	}
+}
+
+// --- Pointer identity ---
+
+func TestSame(t *testing.T) {
+	x := 42
+	y := 42
+	s := "foo"
+	var nilInt *int
+	var nilStr *string
+
+	cases := []struct {
+		Name string
+		E, A interface{}
+		O    bool
+	}{
+		{"same pointer", &x, &x, true},
+		{"different pointers same type", &x, &y, false},
+		{"different pointer types", &x, &s, false},
+		{"both typed nil same type", nilInt, nilInt, true},
+		{"both typed nil different types", nilInt, nilStr, false},
+		{"non-pointer", 42, 42, false},
+		{"one non-pointer", &x, 42, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if Same(wt, tc.E, tc.A) != tc.O {
+				t.Errorf("Same(%v, %v) should be %v", tc.E, tc.A, tc.O)
+			}
+		})
+	}
+}
+
+func TestNotSame(t *testing.T) {
+	x := 42
+	y := 42
+	var nilInt *int
+	var nilStr *string
+
+	cases := []struct {
+		Name string
+		E, A interface{}
+		O    bool
+	}{
+		{"same pointer", &x, &x, false},
+		{"different pointers same type", &x, &y, true},
+		{"both typed nil same type", nilInt, nilInt, false},
+		{"both typed nil different types", nilInt, nilStr, true},
+		{"non-pointer", 42, 42, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if NotSame(wt, tc.E, tc.A) != tc.O {
+				t.Errorf("NotSame(%v, %v) should be %v", tc.E, tc.A, tc.O)
+			}
+		})
+	}
+}
+
+// --- Numeric / value ---
+
+func TestZero(t *testing.T) {
+	var nilP *int
+	cases := []struct {
+		Name string
+		V    interface{}
+		O    bool
+	}{
+		{"nil interface", nil, true},
+		{"zero int", 0, true},
+		{"non-zero int", 42, false},
+		{"empty string", "", true},
+		{"non-empty string", "hi", false},
+		{"zero struct", SomeStruct{}, true},
+		{"non-zero struct", SomeStruct{Value: 42}, false},
+		{"typed nil pointer", nilP, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if Zero(wt, tc.V) != tc.O {
+				t.Errorf("Zero(%v) should be %v", tc.V, tc.O)
+			}
+		})
+	}
+}
+
+func TestNotZero(t *testing.T) {
+	var nilP *int
+	cases := []struct {
+		Name string
+		V    interface{}
+		O    bool
+	}{
+		{"nil interface", nil, false},
+		{"zero int", 0, false},
+		{"non-zero int", 42, true},
+		{"zero struct", SomeStruct{}, false},
+		{"non-zero struct", SomeStruct{Value: 42}, true},
+		{"typed nil pointer", nilP, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if NotZero(wt, tc.V) != tc.O {
+				t.Errorf("NotZero(%v) should be %v", tc.V, tc.O)
+			}
+		})
+	}
+}
+
+func TestInDelta(t *testing.T) {
+	cases := []struct {
+		Name             string
+		Expected, Actual float64
+		Delta            float64
+		O                bool
+	}{
+		{"exact", 1.0, 1.0, 0.0, true},
+		{"within delta", 1.0, 1.5, 0.5, true},
+		{"on boundary", 1.0, 1.5, 0.5, true},
+		{"exceeds delta", 1.0, 1.5, 0.4, false},
+		{"negative diff within delta", 1.0, 0.5, 0.5, true},
+		{"NaN expected", math.NaN(), 1.0, 1.0, false},
+		{"NaN actual", 1.0, math.NaN(), 1.0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if InDelta(wt, tc.Expected, tc.Actual, tc.Delta) != tc.O {
+				t.Errorf("InDelta(%v, %v, %v) should be %v", tc.Expected, tc.Actual, tc.Delta, tc.O)
+			}
+		})
+	}
+}
+
+// --- Regex ---
+
+func TestRegexp(t *testing.T) {
+	rx := regexp.MustCompile(`\d+`)
+	cases := []struct {
+		Name    string
+		Pattern interface{}
+		Str     string
+		O       bool
+	}{
+		{"string match", "foo.*", "foobar", true},
+		{"string no match", "^bar", "foobar", false},
+		{"compiled match", rx, "abc123", true},
+		{"compiled no match", rx, "abcdef", false},
+		{"invalid pattern", "[invalid", "x", false},
+		{"wrong pattern type", 42, "x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if Regexp(wt, tc.Pattern, tc.Str) != tc.O {
+				t.Errorf("Regexp(%v, %q) should be %v", tc.Pattern, tc.Str, tc.O)
+			}
+		})
+	}
+}
+
+func TestNotRegexp(t *testing.T) {
+	cases := []struct {
+		Name    string
+		Pattern interface{}
+		Str     string
+		O       bool
+	}{
+		{"string match", "foo.*", "foobar", false},
+		{"string no match", "^bar", "foobar", true},
+		{"invalid pattern", "[invalid", "x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			wt := wrap(t)
+			if NotRegexp(wt, tc.Pattern, tc.Str) != tc.O {
+				t.Errorf("NotRegexp(%v, %q) should be %v", tc.Pattern, tc.Str, tc.O)
+			}
+		})
+	}
+}
+
+// --- Panic ---
+
+func TestNotPanics(t *testing.T) {
+	t.Run("non-panicking", func(t *testing.T) {
+		wt := wrap(t)
+		if !NotPanics(wt, func() {}) {
+			t.Errorf("NotPanics should pass for non-panicking func")
+		}
+	})
+	t.Run("panicking", func(t *testing.T) {
+		wt := wrap(t)
+		if NotPanics(wt, func() { panic("boom") }) {
+			t.Errorf("NotPanics should fail for panicking func")
+		}
+	})
 }

--- a/internal/tests/lib.go
+++ b/internal/tests/lib.go
@@ -24,6 +24,7 @@ func (t *tWrapper) LastFailure() *fail.TestFailure {
 
 func failTest(t testing.T, tf fail.TestFailure) bool {
 	t.Helper()
+	tf = tf.WithStack(2)
 	t.Log(tf.Format("test"))
 	wt := t.(*tWrapper)
 	wt.Failures = append(wt.Failures, tf)

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -4,7 +4,10 @@ package tests
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/rubrikinc/testwell/internal/cmp"
@@ -3901,6 +3904,52 @@ func Len(t testing.T, container interface{}, expected int, msg ...interface{}) b
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// ElementsMatch tests if `expected` and `actual` contain the same elements
+// regardless of order. Both must be slices or arrays.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Contains, DeepEqual.
+func ElementsMatch(t testing.T,
+	expected interface{},
+	actual interface{},
+	msg ...interface{}) bool {
+	t.Helper()
+
+	ok, err := cmp.ElementsMatch(expected, actual)
+	failure := fail.Failure("ElementsMatch")
+	if err != nil {
+		failure = failure.Error(err)
+	} else if ok {
+		return true
+	} else {
+		failure = failure.Reason("slices contain different elements").
+			LeftValue(expected).RightValue(actual)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotElementsMatch tests if `expected` and `actual` do not contain the same
+// elements (regardless of order). Both must be slices or arrays.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotContains, NotDeepEqual.
+func NotElementsMatch(t testing.T,
+	expected interface{},
+	actual interface{},
+	msg ...interface{}) bool {
+	t.Helper()
+
+	ok, err := cmp.ElementsMatch(expected, actual)
+	failure := fail.Failure("NotElementsMatch")
+	if err != nil {
+		failure = failure.Error(err)
+	} else if !ok {
+		return true
+	} else {
+		failure = failure.Reason("slices contain the same elements").
+			LeftValue(expected).RightValue(actual)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // DeepEqual tests if `left` == `right` using `reflect.DeepEqual`.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 // This is a deep, recursive equality test. See also `Equal`.
@@ -3983,6 +4032,103 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 		Reason("expected different pointers, got the same").
 		LeftValue(expected).RightValue(actual).
 		ExtraMsg(msg...))
+}
+
+// Zero tests if val is the zero value for its type.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+		return true
+	}
+	return failTest(t, fail.Failure("Zero").
+		Reason("expected zero value, got `%v` (%T)", val, val).
+		ExtraMsg(msg...))
+}
+
+// NotZero tests if val is not the zero value for its type.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotZero").
+		Reason("expected non-zero value, got `%v` (%T)", val, val).
+		ExtraMsg(msg...))
+}
+
+// InDelta tests if the absolute difference between expected and actual is
+// less than or equal to delta. Useful for floating-point comparisons.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func InDelta(t testing.T,
+	expected float64,
+	actual float64,
+	delta float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	diff := math.Abs(actual - expected)
+	if diff <= delta {
+		return true
+	}
+	return failTest(t, fail.Failure("InDelta").
+		Reason("|actual - expected| = %v, which exceeds delta %v", diff, delta).
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
+}
+
+// Regexp tests if str matches the given pattern. pattern can be a string or
+// a *regexp.Regexp.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotRegexp.
+func Regexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+	t.Helper()
+
+	rx, err := toRegexp(pattern)
+	if err != nil {
+		return failTest(t, fail.Failure("Regexp").Error(err).ExtraMsg(msg...))
+	}
+	if rx.MatchString(str) {
+		return true
+	}
+	return failTest(t, fail.Failure("Regexp").
+		Reason("expected %q to match pattern %q", str, rx.String()).
+		LeftValue(str).RightValue(rx.String()).
+		ExtraMsg(msg...))
+}
+
+// NotRegexp tests if str does not match the given pattern. pattern can be a
+// string or a *regexp.Regexp.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Regexp.
+func NotRegexp(t testing.T, pattern interface{}, str string, msg ...interface{}) bool {
+	t.Helper()
+
+	rx, err := toRegexp(pattern)
+	if err != nil {
+		return failTest(t, fail.Failure("NotRegexp").Error(err).ExtraMsg(msg...))
+	}
+	if !rx.MatchString(str) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotRegexp").
+		Reason("expected %q not to match pattern %q", str, rx.String()).
+		LeftValue(str).RightValue(rx.String()).
+		ExtraMsg(msg...))
+}
+
+func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
+	switch v := pattern.(type) {
+	case string:
+		return regexp.Compile(v)
+	case *regexp.Regexp:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("pattern must be string or *regexp.Regexp, got %T", pattern)
+	}
 }
 
 // Failed logs a message and fails the test.

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -3,7 +3,9 @@
 package tests
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 
 	"github.com/rubrikinc/testwell/internal/cmp"
 	"github.com/rubrikinc/testwell/internal/fail"
@@ -1378,6 +1380,1094 @@ func NotEqualUintptr(t testing.T,
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// GreaterByte tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterByte").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualByte tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualByte").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessByte tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessByte").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualByte tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualByte(t testing.T,
+	left byte,
+	right byte,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualByte").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterFloat32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterFloat32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualFloat32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualFloat32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessFloat32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessFloat32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualFloat32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualFloat32(t testing.T,
+	left float32,
+	right float32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualFloat32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterFloat64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterFloat64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualFloat64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualFloat64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessFloat64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessFloat64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualFloat64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualFloat64(t testing.T,
+	left float64,
+	right float64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualFloat64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt(t testing.T,
+	left int,
+	right int,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt16 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt16").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt16 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt16").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt16 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt16").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt16 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt16(t testing.T,
+	left int16,
+	right int16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt16").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt32(t testing.T,
+	left int32,
+	right int32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt64(t testing.T,
+	left int64,
+	right int64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterInt8 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterInt8").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualInt8 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualInt8").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessInt8 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessInt8").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualInt8 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualInt8(t testing.T,
+	left int8,
+	right int8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualInt8").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterRune tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterRune").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualRune tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualRune").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessRune tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessRune").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualRune tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualRune(t testing.T,
+	left rune,
+	right rune,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualRune").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterString tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterString").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualString tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualString").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessString tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessString").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualString tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualString(t testing.T,
+	left string,
+	right string,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualString").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint(t testing.T,
+	left uint,
+	right uint,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint16 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint16").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint16 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint16").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint16 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint16").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint16 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint16(t testing.T,
+	left uint16,
+	right uint16,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint16").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint32 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint32").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint32 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint32").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint32 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint32").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint32 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint32(t testing.T,
+	left uint32,
+	right uint32,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint32").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint64 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint64").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint64 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint64").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint64 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint64").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint64 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint64(t testing.T,
+	left uint64,
+	right uint64,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint64").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUint8 tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUint8").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUint8 tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUint8").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUint8 tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUint8").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUint8 tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUint8(t testing.T,
+	left uint8,
+	right uint8,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUint8").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterUintptr tests if `left` is strictly greater than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left > right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterUintptr").
+		Reason("expected left > right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// GreaterOrEqualUintptr tests if `left` is greater than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func GreaterOrEqualUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left >= right {
+		return true
+	}
+	return failTest(t, fail.Failure("GreaterOrEqualUintptr").
+		Reason("expected left >= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessUintptr tests if `left` is strictly less than `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left < right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessUintptr").
+		Reason("expected left < right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
+// LessOrEqualUintptr tests if `left` is less than or equal to `right`.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func LessOrEqualUintptr(t testing.T,
+	left uintptr,
+	right uintptr,
+	msg ...interface{}) bool {
+	t.Helper()
+
+	if left <= right {
+		return true
+	}
+	return failTest(t, fail.Failure("LessOrEqualUintptr").
+		Reason("expected left <= right").
+		LeftValue(left).RightValue(right).
+		ExtraMsg(msg...))
+}
+
 // EqualTypes tests if `left` and `right` have the same type.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 // Example:
@@ -2655,6 +3745,99 @@ func NotNil(t testing.T, tval interface{}, msg ...interface{}) bool {
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
+// NoError tests if err is nil.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Error, ErrorIs, ErrorAs, ErrorContains.
+func NoError(t testing.T, err error, msg ...interface{}) bool {
+	t.Helper()
+
+	if err == nil {
+		return true
+	}
+	return failTest(t, fail.Failure("NoError").
+		Reason("expected no error, got: %v", err).
+		ExtraMsg(msg...))
+}
+
+// Error tests if err is not nil.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NoError, ErrorIs, ErrorAs, ErrorContains.
+func Error(t testing.T, err error, msg ...interface{}) bool {
+	t.Helper()
+
+	if err != nil {
+		return true
+	}
+	return failTest(t, fail.Failure("Error").
+		Reason("expected an error but got nil").
+		ExtraMsg(msg...))
+}
+
+// ErrorIs tests if errors.Is(err, target) is true.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also NotErrorIs, NoError, Error.
+func ErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+	t.Helper()
+
+	if errors.Is(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("ErrorIs").
+		Reason("errors.Is(err, target) returned false").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// NotErrorIs tests if errors.Is(err, target) is false.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also ErrorIs, NoError, Error.
+func NotErrorIs(t testing.T, err error, target error, msg ...interface{}) bool {
+	t.Helper()
+
+	if !errors.Is(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("NotErrorIs").
+		Reason("errors.Is(err, target) returned true").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// ErrorAs tests if errors.As(err, target) is true.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// target must be a non-nil pointer to either a type that implements error,
+// or to any interface type. See also NotErrorAs.
+func ErrorAs(t testing.T, err error, target interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	if errors.As(err, target) {
+		return true
+	}
+	return failTest(t, fail.Failure("ErrorAs").
+		Reason("errors.As(err, target) returned false").
+		LeftValue(err).RightValue(target).
+		ExtraMsg(msg...))
+}
+
+// ErrorContains tests if err is not nil and err.Error() contains substr.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+// See also Error, ErrorIs.
+func ErrorContains(t testing.T, err error, substr string, msg ...interface{}) bool {
+	t.Helper()
+
+	if err != nil && strings.Contains(err.Error(), substr) {
+		return true
+	}
+	failure := fail.Failure("ErrorContains")
+	if err == nil {
+		failure = failure.Reason("expected an error containing %q, got nil", substr)
+	} else {
+		failure = failure.Reason("expected error to contain %q", substr).
+			LeftValue(err.Error()).RightValue(substr)
+	}
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
 // Empty tests if the passed value is Empty. A nil container or a container
 // with zero elements are both empty. Uses Go len().
 // Container can be any of Array, Chan, Map, Slice, or String.
@@ -2690,6 +3873,31 @@ func NotEmpty(t testing.T, container interface{}, msg ...interface{}) bool {
 		return true
 	}
 	failure = failure.Reason("`%v` (%T) should not be empty", container, container)
+	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Len tests if the length of container equals expected. Uses Go len().
+// Container can be any of Array, Chan, Map, Slice, or String.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Len(t testing.T, container interface{}, expected int, msg ...interface{}) bool {
+	t.Helper()
+
+	v := reflect.ValueOf(container)
+	actual := -1
+	switch v.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		actual = v.Len()
+	}
+	if actual == expected {
+		return true
+	}
+	failure := fail.Failure("Len")
+	if actual == -1 {
+		failure = failure.Reason("`%v` (%T) does not support Len", container, container)
+	} else {
+		failure = failure.Reason("expected length %d, got %d", expected, actual).
+			LeftValue(expected).RightValue(actual)
+	}
 	return failTest(t, failure.ExtraMsg(msg...))
 }
 
@@ -2733,6 +3941,48 @@ func NotDeepEqual(t testing.T,
 		LeftValue(left).
 		RightValue(right)
 	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// Same tests if expected and actual point to the same object (pointer identity).
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	ev := reflect.ValueOf(expected)
+	av := reflect.ValueOf(actual)
+	if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+		return failTest(t, fail.Failure("Same").
+			Reason("both arguments must be pointers").
+			ExtraMsg(msg...))
+	}
+	if ev.Pointer() == av.Pointer() {
+		return true
+	}
+	return failTest(t, fail.Failure("Same").
+		Reason("expected the same pointer").
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
+}
+
+// NotSame tests if expected and actual do not point to the same object.
+// msg is an optional list of arguments following the `fmt.Printf()` format.
+func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
+	t.Helper()
+
+	ev := reflect.ValueOf(expected)
+	av := reflect.ValueOf(actual)
+	if ev.Kind() != reflect.Ptr || av.Kind() != reflect.Ptr {
+		return failTest(t, fail.Failure("NotSame").
+			Reason("both arguments must be pointers").
+			ExtraMsg(msg...))
+	}
+	if ev.Pointer() != av.Pointer() {
+		return true
+	}
+	return failTest(t, fail.Failure("NotSame").
+		Reason("expected different pointers, got the same").
+		LeftValue(expected).RightValue(actual).
+		ExtraMsg(msg...))
 }
 
 // Failed logs a message and fails the test.
@@ -2781,4 +4031,18 @@ func PanicsWith(t testing.T,
 		return true
 	}
 	return failTest(t, failure.ExtraMsg(msg...))
+}
+
+// NotPanics asserts that the code inside the specified function f does not panic.
+//
+//	assert.NotPanics(t, func(){ Sane() })
+func NotPanics(t testing.T, f func(), msg ...interface{}) bool {
+	t.Helper()
+
+	if funcDidPanic, panicValue := cmp.Panics(f); funcDidPanic {
+		failure := fail.Failure("NotPanics")
+		failure = failure.Reason("Expected function not to panic\n\tPanic value:\t%v", panicValue)
+		return failTest(t, failure.ExtraMsg(msg...))
+	}
+	return true
 }

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -3959,7 +3959,7 @@ func DeepEqual(t testing.T,
 	msg ...interface{}) bool {
 	t.Helper()
 
-	failure := fail.Failure("DeepEqual{")
+	failure := fail.Failure("DeepEqual")
 
 	if reflect.DeepEqual(left, right) {
 		return true
@@ -4041,7 +4041,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
 	t.Helper()
 
-	if val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+	if val == nil || reflect.ValueOf(val).IsZero() {
 		return true
 	}
 	return failTest(t, fail.Failure("Zero").
@@ -4054,7 +4054,7 @@ func Zero(t testing.T, val interface{}, msg ...interface{}) bool {
 func NotZero(t testing.T, val interface{}, msg ...interface{}) bool {
 	t.Helper()
 
-	if val != nil && !reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface()) {
+	if val != nil && !reflect.ValueOf(val).IsZero() {
 		return true
 	}
 	return failTest(t, fail.Failure("NotZero").
@@ -4138,7 +4138,7 @@ func toRegexp(pattern interface{}) (*regexp.Regexp, error) {
 func Failed(t testing.T, fmtstr string, args ...interface{}) {
 	t.Helper()
 
-	failure := fail.Failure("Custom")
+	failure := fail.Failure("Failed")
 	failure = failure.Reason(fmtstr, args...)
 	failTest(t, failure)
 }
@@ -4150,7 +4150,7 @@ func Panics(t testing.T, f func(), msg ...interface{}) bool {
 	t.Helper()
 
 	if funcDidPanic, _ := cmp.Panics(f); !funcDidPanic {
-		failure := fail.Failure("Panic")
+		failure := fail.Failure("Panics")
 		failure = failure.Reason("Expected function %#v to panic", f)
 		return failTest(t, failure.ExtraMsg(msg...))
 	}
@@ -4168,7 +4168,7 @@ func PanicsWith(t testing.T,
 	t.Helper()
 
 	funcDidPanic, panicValue := cmp.Panics(f)
-	failure := fail.Failure("PanicWithValue")
+	failure := fail.Failure("PanicsWith")
 
 	if !funcDidPanic {
 		failure = failure.Reason("Expected %#v to panic", f)

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -3993,6 +3993,7 @@ func NotDeepEqual(t testing.T,
 }
 
 // Same tests if expected and actual point to the same object (pointer identity).
+// Both arguments must be pointers of the same type.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func Same(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
 	t.Helper()
@@ -4004,7 +4005,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
 			Reason("both arguments must be pointers").
 			ExtraMsg(msg...))
 	}
-	if ev.Pointer() == av.Pointer() {
+	if reflect.TypeOf(expected) == reflect.TypeOf(actual) && ev.Pointer() == av.Pointer() {
 		return true
 	}
 	return failTest(t, fail.Failure("Same").
@@ -4014,6 +4015,7 @@ func Same(t testing.T, expected interface{}, actual interface{}, msg ...interfac
 }
 
 // NotSame tests if expected and actual do not point to the same object.
+// Both arguments must be pointers; pointers of different types are never the same.
 // msg is an optional list of arguments following the `fmt.Printf()` format.
 func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...interface{}) bool {
 	t.Helper()
@@ -4025,7 +4027,7 @@ func NotSame(t testing.T, expected interface{}, actual interface{}, msg ...inter
 			Reason("both arguments must be pointers").
 			ExtraMsg(msg...))
 	}
-	if ev.Pointer() != av.Pointer() {
+	if reflect.TypeOf(expected) != reflect.TypeOf(actual) || ev.Pointer() != av.Pointer() {
 		return true
 	}
 	return failTest(t, fail.Failure("NotSame").


### PR DESCRIPTION
## Summary

- Add 80+ new assertions across `assert` and `expect`: error handling (`NoError`/`Error`/`ErrorIs`/`NotErrorIs`/`ErrorAs`/`ErrorContains`), typed ordering for 16 ordered types (`Greater`/`GreaterOrEqual`/`Less`/`LessOrEqual` × `int…uint64`, `float32`/`float64`, `byte`/`rune`/`string`/`uintptr` = 64 functions), `Len`, `ElementsMatch`/`NotElementsMatch`, `Same`/`NotSame`, `Zero`/`NotZero`, `InDelta`, `Regexp`/`NotRegexp`, `NotPanics`. Function count: 97 → 179 per package.
- Make the success path of every assertion cheaper: `fail.Failure()` is now a one-line struct literal — `runtime.Callers` capture and `LeftValue`/`RightValue` `fmt.Sprintf` are deferred to the failure path via a new `WithStack(skip)` method called from each `failTest`. Equal/Contains/Nil/Empty/DeepEqual no longer allocate a stack trace on every passing call.
- Bug fix: `Same(t, (*int)(nil), (*string)(nil))` previously returned true (both pointer addresses were 0). Now requires `reflect.TypeOf(expected) == reflect.TypeOf(actual)` in addition to address equality, matching testify's `samePointers` semantics. `NotSame` updated symmetrically.
- Cleanups: fix four assertion names that didn't match their function names (`"DeepEqual{"` typo, `"Custom"` → `"Failed"`, `"Panic"` → `"Panics"`, `"PanicWithValue"` → `"PanicsWith"`), replace `Zero`/`NotZero`'s `reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface())` with `reflect.Value.IsZero()`, collapse empty-body fall-through case lists in `cmp/empty.go` and `cmp/nil.go`, replace deprecated `strings.Title` in codegen with a 5-line ASCII helper (no new dep — codegen only ever capitalizes lowercase ASCII type identifiers).

## Test plan

- [x] `make` green (build + generate + test)
- [x] `go test -vet off ./internal/tests/` passes — added 18 new test functions covering the new assertions; coverage of `internal/tests` and `internal/cmp` rose from 10.7% → 20.9%, with `cmp.ElementsMatch` at 96% and `cmp.Panics` (a pre-existing 0% gap) now at 100%
- [x] Verified `Same`/`NotSame` correctly reject cross-typed nil pointers — the bug fix is covered by `TestSame`/`TestNotSame`
- [x] Confirmed regenerated `assert.go`/`expect.go`/`tests.go` are byte-identical after the `strings.Title` → inline `capitalize` swap (no behavioral change in generated code)
- [x] Sample failure output verified — stack trace still resolves to the calling test function with the same depth as before the lazy-capture refactor; the rendered failure message format is unchanged